### PR TITLE
Keeps original toot format (newlines etc.)

### DIFF
--- a/requirements.python35.txt
+++ b/requirements.python35.txt
@@ -9,3 +9,4 @@ requests==2.13.0
 requests-oauthlib==0.8.0
 six==1.10.0
 tweepy==3.5.0
+html2text==2016.9.19

--- a/supportbot/supportbot.py
+++ b/supportbot/supportbot.py
@@ -40,7 +40,7 @@ class SupportListener(StreamListener):
             self.client.get_client().status_post(body, visibility='public')
         else:
             #reply with help message
-            body = "Hi, @" + notification['account']['username'] + "\n\n"
+            body = "Hi, @" + notification['account']['acct'] + "\n\n"
             body += self.client.config.get('support_bot', 'reply_txt',
                                            fallback="Thank you for using Mastodon! I'm just a support bot, but I'm sure our admins will help you soon")
             body += "\n\n"

--- a/supportbot/supportbot.py
+++ b/supportbot/supportbot.py
@@ -1,31 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from html.parser import HTMLParser
-
+from html2text import HTML2Text
 
 from bot import Bot
 from mastodon.streaming import StreamListener
 
-
-class MLStripper(HTMLParser):
-    def __init__(self):
-        self.reset()
-        self.strict = False
-        self.convert_charrefs = True
-        self.fed = []
-
-    def handle_data(self, d):
-        self.fed.append(d)
-
-    def get_data(self):
-        return ''.join(self.fed)
-
-
 def strip_tags(html):
-    s = MLStripper()
-    s.feed(html)
-    return s.get_data()
-
+    h = HTML2Text()
+    h.ignore_links = True
+    t = h.handle(html)
+    return t.strip()
 
 class SupportListener(StreamListener):
 


### PR DESCRIPTION
- Instead of stripping HTML tags, I made a conversion in markdown. Doing so allow the bot to preserve new lines.
- When a remote user mentionned the bot, there was only the local part of their username so they were not properly mentionned back. I changed the property used with the one that includes the domain part.